### PR TITLE
Run cpplint only on files that differ from master

### DIFF
--- a/.github/workflows/cpplint_modified_files.yml
+++ b/.github/workflows/cpplint_modified_files.yml
@@ -1,6 +1,8 @@
-# GitHub Action that runs cpplint only on those files that have been modified vs. origin/master
-# This allows for gradual compliance with cpplint as only files added or modified are checked.
-# Other optional filepath verifications are commented out at the end of this file.
+# GitHub Action that enables a repo to achieve gradual compliance with cpplint by
+#     linting only those files that have been added or modified (vs. origin/master).
+# 1. runs cpplint only on those files that have been modified vs. origin/master.
+# 2. compiles with g++ only those files that have been modified vs. origin/master.
+# 3. other optional filepath verifications may be commented out at the end of this file.
 
 name: cpplint_modified_files
 on: [push, pull_request]
@@ -10,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v1
+      - shell: python  # Show the version of shell: python and then upgrade shell: python to Python 3.8
+        run: import sys ; print("Python {}.{}.{}".format(*sys.version_info))  # Legacy Python :-(
+      - run: sudo update-alternatives --install /usr/bin/python python ${pythonLocation}/bin/python3.8 10
       - run: python -m pip install cpplint
       - run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
       - run: git diff origin/master --name-only > git_diff.txt
@@ -20,33 +25,38 @@ jobs:
           import subprocess
           import sys
 
-          print("Python {}.{}.{}".format(*sys.version_info))  # legacy Python :-(
+          print("Python {}.{}.{}".format(*sys.version_info))  # Python 3.8
           with open("git_diff.txt") as in_file:
             modified_files = sorted(in_file.read().splitlines())
           print("{} files were modified.".format(len(modified_files)))
 
           cpp_exts = tuple(".c .c++ .cc .cpp .cu .cuh .cxx .h .h++ .hh .hpp .hxx".split())
           cpp_files = [file for file in modified_files if file.lower().endswith(cpp_exts)]
-          print("{} C++ files were modified.".format(len(cpp_files)))
+          print(f"{len(cpp_files)} C++ files were modified.")
           if not cpp_files:
             sys.exit(0)
 
           print("cpplint:")
-          print(subprocess.check_output(["cpplint"] + cpp_files).decode("utf-8"))
+          subprocess.run(["cpplint", "--filter=-legal/copyright"] + cpp_files, check=True, text=True)
+
+          print("g++:")
+          # compile_exts = tuple(".c .c++ .cc .cpp .cu .cxx".split())
+          # compile_files = [file for file in cpp_files if file.lower().endswith(compile_exts)]
+          subprocess.run(["g++"] + cpp_files, check=True, text=True)
 
           # upper_files = [file for file in cpp_files if file != file.lower()]
           # if upper_files:
-          #   print("{} files contain uppercase characters:".format(len(upper_files)))
+          #   print(f"{len(upper_files)} files contain uppercase characters:")
           #   print("\n".join(upper_files) + "\n")
 
           # space_files = [file for file in cpp_files if " " in file or "-" in file]
           # if space_files:
-          #   print("{} files contain space or dash characters:".format(len(space_files)))
+          #   print(f"{len(space_files)} files contain space or dash characters:")
           #   print("\n".join(space_files) + "\n")
 
-          # nodir_files = [file for file in cpp_files if os.sep not in file]
+          # nodir_files = [file for file in cpp_files if file.count(os.sep) != 1]
           # if nodir_files:
-          #   print("{} files are not in a directory:".format(len(nodir_files)))
+          #   print(f"{len(nodir_files)} files are not in one and only one directory:")
           #   print("\n".join(nodir_files) + "\n")
 
           # bad_files = len(upper_files + space_files + nodir_files)

--- a/.github/workflows/cpplint_modified_files.yml
+++ b/.github/workflows/cpplint_modified_files.yml
@@ -1,0 +1,54 @@
+# GitHub Action that runs cpplint only on those files that have been modified vs. origin/master
+# This allows for gradual compliance with cpplint as only files added or modified are checked.
+# Other optional filepath verifications are commented out at the end of this file.
+
+name: cpplint_modified_files
+on: [push, pull_request]
+jobs:
+  cpplint_modified_files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-python@v1
+      - run: python -m pip install cpplint
+      - run: git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY
+      - run: git diff origin/master --name-only > git_diff.txt
+      - name: cpplint_modified_files
+        shell: python
+        run: |
+          import os
+          import subprocess
+          import sys
+
+          print("Python {}.{}.{}".format(*sys.version_info))  # legacy Python :-(
+          with open("git_diff.txt") as in_file:
+            modified_files = sorted(in_file.read().splitlines())
+          print("{} files were modified.".format(len(modified_files)))
+
+          cpp_exts = tuple(".c .c++ .cc .cpp .cu .cuh .cxx .h .h++ .hh .hpp .hxx".split())
+          cpp_files = [file for file in modified_files if file.lower().endswith(cpp_exts)]
+          print("{} C++ files were modified.".format(len(cpp_files)))
+          if not cpp_files:
+            sys.exit(0)
+
+          print("cpplint:")
+          print(subprocess.check_output(["cpplint"] + cpp_files).decode("utf-8"))
+
+          # upper_files = [file for file in cpp_files if file != file.lower()]
+          # if upper_files:
+          #   print("{} files contain uppercase characters:".format(len(upper_files)))
+          #   print("\n".join(upper_files) + "\n")
+
+          # space_files = [file for file in cpp_files if " " in file or "-" in file]
+          # if space_files:
+          #   print("{} files contain space or dash characters:".format(len(space_files)))
+          #   print("\n".join(space_files) + "\n")
+
+          # nodir_files = [file for file in cpp_files if os.sep not in file]
+          # if nodir_files:
+          #   print("{} files are not in a directory:".format(len(nodir_files)))
+          #   print("\n".join(nodir_files) + "\n")
+
+          # bad_files = len(upper_files + space_files + nodir_files)
+          # if bad_files:
+          #   sys.exit(bad_files)


### PR DESCRIPTION
GitHub Action that enables a repo to achieve gradual compliance with cpplint by linting only those files that have been added or modified (vs. origin/master).
1. runs cpplint only on those files that have been modified vs. origin/master.
2. compiles with g++ only those files that have been modified vs. origin/master.
3. other optional filepath verifications may be commented out at the end of this file.